### PR TITLE
User can favorite a buoy station and filter by favorited.

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -36,3 +36,23 @@ export const fetchBuoys = (URL = BUOY_URL) => {
     );
   };
 };
+
+export const TOGGLE_FAVORITE = 'TOGGLE_FAVORITE';
+
+export const toggleFavorite = id => {
+  return {
+    type: TOGGLE_FAVORITE,
+    payload: id
+  };
+};
+
+export const SHOW_ALL = 'SHOW_ALL';
+export const SHOW_FAVORITE = 'SHOW_FAVORITE';
+export const SET_VISIBILITY_FILTER = 'SET_VISIBILITY_FILTER';
+
+export const setVisibilityFilter = (filter) => {
+  return {
+    type: SET_VISIBILITY_FILTER,
+    payload: filter
+  };
+};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,32 +1,49 @@
 import { connect } from 'react-redux';
 import React from 'react';
+import {
+  setVisibilityFilter,
+  SHOW_ALL,
+  SHOW_FAVORITE
+} from '../actions';
 
-
-const ReadyHeader = ({header}) => {
-  const {description, pubDate, title} = header;
+const ReadyHeader = ({state}) => {
+  const {description, pubDate, title} = state.header;
+  const {onFilterClick} = state;
   return (
     <div>
       <h2>{title}</h2>
       <p>{description}</p>
       <p>{pubDate}</p>
+      <p>
+        <span onClick={() => onFilterClick(SHOW_ALL)}>show all </span>
+        <span onClick={() => onFilterClick(SHOW_FAVORITE)}>show favorites </span>
+      </p>
     </div>
     );
 };
 
 const Header = (state) => {
-  const {loading, header} = state;
+  const {loading} = state;
 
-  return loading ? <h3>Loading</h3> : <ReadyHeader header={header}/>;
+  return loading ? <h3>Loading</h3> : <ReadyHeader state={state}/>;
 };
 
 const mapStateToProps = ({buoys}) => {
-  const {loading, header} = buoys;
+  const {loading, header, userData} = buoys;
   return {
     loading,
-    header
+    header,
+    userData
   };
 };
 
+const mapDispatchToProps = (dispatch) => {
+  return {
+      onFilterClick: (filter) => {
+        dispatch(setVisibilityFilter(filter));
+      }
+  };
+};
 
-const ConnectedHeader = connect(mapStateToProps)(Header);
+const ConnectedHeader = connect(mapStateToProps, mapDispatchToProps)(Header);
 export default ConnectedHeader;

--- a/src/components/Stations.js
+++ b/src/components/Stations.js
@@ -1,12 +1,15 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import R from 'ramda';
+import { toggleFavorite } from '../actions';
+
 
 const Container = children => (<ul>{children}</ul>);
+const Star = b => b ? <span>&#x2605;</span> : <span>&#x2606;</span>;
 
 const StationData = (val, key, obj) => {
   return (
-    <li key={obj.id + val}>
+    <li key={val + key}>
       <b>{key}: </b><span>{val}</span>
     </li>
   );
@@ -14,31 +17,72 @@ const StationData = (val, key, obj) => {
 
 const PropertyList = R.pipe(
   R.prop('description'),
+  R.pick(['Location', 'Significant Wave Height', 'Average Period']),
   R.mapObjIndexed(StationData),
   R.values,
   Container
 );
 
-const Station = (station) => {
+const Station = R.curry((dispatches, station) => {
   const {title, id} = station;
   return (
-    <li key={id}>
-      <h4>{title}</h4>
+    <li key={id} >
+      <h4>
+      <span
+        onClick={() => dispatches.onStationClick(id)}>{Star(station.favorite)}
+      </span>
+      <span>{title}</span>
+      </h4>
       {PropertyList(station)}
     </li>
   );
+});
+
+const mapStations = ({stations, dispatches}) => {
+  return R.map(Station(dispatches), stations); 
 };
 
-
 const StationList = R.pipe(
-  R.prop('stations'),
-  R.map(Station),
+  mapStations,
   R.values,
   Container
 );
 
-const mapStateToProps = ({buoys}) => ({stations: buoys.stations});
+const getFavoriteBuoys = (stations, filter) => {
+  switch (filter) {
+  case 'SHOW_FAVORITE':
+    return R.filter(R.prop('favorite'), stations);
+  default: { return stations; }
+  }
+};
+
+const mergeLocal = (buoys) => {
+  return R.mergeWith(R.merge, buoys.userData.stations, buoys.stations);
+};
+
+const getVisibleStations = (buoys) => {
+  const merged = mergeLocal(buoys);
+  return getFavoriteBuoys(merged, buoys.userData.visibilityFilter);
+};
+
+const mapStateToProps = ({buoys}) => (
+  {
+    stations: getVisibleStations(buoys),
+    userData: buoys.userData
+  }
+);
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    dispatches: {
+      onStationClick: (id) => {
+        dispatch(toggleFavorite(id));
+      }
+    }
+  };
+};
 
 
-const ConnectedStations = connect(mapStateToProps)(StationList);
+const ConnectedStations = connect(mapStateToProps, mapDispatchToProps)(StationList);
+
 export default ConnectedStations;

--- a/src/reducers/buoys.js
+++ b/src/reducers/buoys.js
@@ -4,7 +4,9 @@ import { combineReducers } from 'redux';
 import {
   BUOYS_REQUEST,
   BUOYS_SUCCESS,
-  BUOYS_FAILURE
+  BUOYS_FAILURE,
+  TOGGLE_FAVORITE,
+  SET_VISIBILITY_FILTER
 } from '../actions/index';
 
 export const loading = (state = false, action) => {
@@ -52,10 +54,27 @@ export const stations = (state = {}, action) => {
   }
 };
 
+export const userData = (state = {}, action) => {
+  switch (action.type) {
+  case TOGGLE_FAVORITE: {
+    const idLens = R.lensPath(['stations', action.payload, 'favorite']);
+
+    return R.over(idLens, R.not, state);
+  }
+  case SET_VISIBILITY_FILTER: {
+    return R.assoc('visibilityFilter', action.payload, state);
+  }
+  default: {
+    return state;
+  }
+  }
+};
+
 const buoys = combineReducers({
   loading,
   header,
-  stations
+  stations,
+  userData
 });
 
 export default buoys;


### PR DESCRIPTION
Used a unicode star ★ ☆ for the Favorite button.
Used plain text 'show all' 'show favorites' for filter buttons.
Limited the properties that print, for now, to Location, Wave Height,
and Period, so more buoy stations fit on the screen.
This doesn't _persist_ yet. 

![dec-07-2016 16-43-53](https://cloud.githubusercontent.com/assets/11598/20992958/60400bd6-bc9c-11e6-83f5-b2bb09f5e035.gif)
